### PR TITLE
pg_dump to support 'on conflict update'

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -135,6 +135,9 @@ static SimpleOidList foreign_servers_include_oids = {NULL, NULL};
 static SimpleStringList extension_include_patterns = {NULL, NULL};
 static SimpleOidList extension_include_oids = {NULL, NULL};
 
+static const char *on_conflict_target_columns = NULL;
+static const char *on_conflict_update_clause = NULL;
+
 static const CatalogId nilCatalogId = {0, 0};
 
 /* override for standard extra_float_digits setting */
@@ -427,6 +430,8 @@ main(int argc, char **argv)
 		{"no-unlogged-table-data", no_argument, &dopt.no_unlogged_table_data, 1},
 		{"no-sync", no_argument, NULL, 7},
 		{"on-conflict-do-nothing", no_argument, &dopt.do_nothing, 1},
+		{"on-conflict-target-columns", required_argument, NULL, 25},
+		{"on-conflict-update-clause", required_argument, NULL, 26},
 		{"rows-per-insert", required_argument, NULL, 10},
 		{"include-foreign-data", required_argument, NULL, 11},
 		{"table-and-children", required_argument, NULL, 12},
@@ -658,6 +663,14 @@ main(int argc, char **argv)
 										  optarg);
 				break;
 
+			case 25:
+				on_conflict_target_columns = pg_strdup(optarg);
+				break;
+
+			case 26:
+				on_conflict_update_clause = pg_strdup(optarg);
+				break;
+
 			default:
 				/* getopt_long already emitted a complaint */
 				pg_log_error_hint("Try \"%s --help\" for more information.", progname);
@@ -714,6 +727,12 @@ main(int argc, char **argv)
 	 */
 	if (dopt.do_nothing && dopt.dump_inserts == 0)
 		pg_fatal("option --on-conflict-do-nothing requires option --inserts, --rows-per-insert, or --column-inserts");
+
+	if (dopt.do_nothing && (on_conflict_target_columns != NULL || on_conflict_update_clause != NULL))
+		pg_fatal("option --on-conflict-do-nothing cannot be used with --on-conflict-target-columns and --on-conflict-do-update-clause");
+
+	if ((on_conflict_target_columns != NULL) ^ (on_conflict_update_clause != NULL))
+		pg_fatal("option --on-conflict-target-columns and --on-conflict-update-clause must be provided together.");
 
 	/* Identify archive format to emit */
 	archiveFormat = parseArchiveFormat(format, &archiveMode);
@@ -1119,6 +1138,8 @@ help(const char *progname)
 	printf(_("  --no-toast-compression       do not dump TOAST compression methods\n"));
 	printf(_("  --no-unlogged-table-data     do not dump unlogged table data\n"));
 	printf(_("  --on-conflict-do-nothing     add ON CONFLICT DO NOTHING to INSERT commands\n"));
+	printf(_("  --on-conflict-target-columns add ON CONFLICT (target-columns) DO UPDATE ... to INSERT commands. A comma-separated list of columns\n"));
+	printf(_("  --on-conflict-update-clause  add the clause ON CONFLICT ... DO UPDATE (clause) to INSERT commands\n"));
 	printf(_("  --quote-all-identifiers      quote all identifiers, even if not key words\n"));
 	printf(_("  --rows-per-insert=NROWS      number of rows per INSERT; implies --inserts\n"));
 	printf(_("  --section=SECTION            dump named section (pre-data, data, or post-data)\n"));
@@ -2479,6 +2500,8 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 			{
 				if (dopt->do_nothing)
 					archputs(" ON CONFLICT DO NOTHING;\n", fout);
+				else if (on_conflict_target_columns != NULL && on_conflict_update_clause != NULL)
+					archprintf(fout, " ON CONFLICT (%s) DO UPDATE SET %s;\n", on_conflict_target_columns, on_conflict_update_clause);
 				else
 					archputs(";\n", fout);
 				/* Reset the row counter */
@@ -2499,6 +2522,8 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	{
 		if (dopt->do_nothing)
 			archputs(" ON CONFLICT DO NOTHING;\n", fout);
+		else if (on_conflict_target_columns != NULL && on_conflict_update_clause != NULL)
+			archprintf(fout, " ON CONFLICT (%s) DO UPDATE SET %s;\n", on_conflict_target_columns, on_conflict_update_clause);
 		else
 			archputs(";\n", fout);
 	}


### PR DESCRIPTION
To compile pg on mac and target Ubuntu (which is used on Github Actions):

```
docker run --rm -ti -v ${PWD}:/project --platform linux/amd64 ubuntu:24.04
apt-get update
apt-get install libreadline-dev zlib1g-dev flex bison libicu-dev pkg-config libssl-dev build-essential libxml2-utils
./configure --with-openssl
make -C src/bin
```

A `pg_dump` binary will be built under `./src/bin/pg_dump/`.

You can see help:

```
LD_LIBRARY_PATH=./src/interfaces/libpq ./src/bin/pg_dump/pg_dump --help
```

Then, we can run:

```
 LD_LIBRARY_PATH=./src/interfaces/libpq ./src/bin/pg_dump/pg_dump $DATABASE_URL \
            --table=open_ai_request_test_cache \
            --data-only \
            --on-conflict-target-columns url,payload_checksum \
            --on-conflict-update-clause='last_used_at=EXCLUDED.last_used_at' \
            --inserts \
            --rows-per-insert=10 \
            --no-sync \
            --file=/tmp/test.dump
```

You can simply copy the binary out and use it e.g. on Github Actions.

Please note that if you have a postgres installed already, you can skip `LD_LIBRARY_PATH=./src/interfaces/libpq` because it will just use the postgres one.
